### PR TITLE
Add ability to set a path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,3 +6,9 @@ branding:
 runs:
   using: "docker"
   image: "Dockerfile"
+
+inputs:
+  path:
+    description: 'Local path'
+    required: false
+    default: ''

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh -l
+LOCAL_PATH="$GITHUB_WORKSPACE/$INPUT_PATH"
+cd $LOCAL_PATH
 
 composer install --prefer-dist --no-ansi --no-interaction --no-progress --no-scripts
 


### PR DESCRIPTION
Hello, 

First of all, thanks for your Github Action.
In one of the projects I've used it, i had a monolith architecture, in our repository, both front and back code are separated in folders at the root of our folder.

As we could not use `working-directory` with `uses` i've decided to fork your repo and made some adjustments.

If you feel like that could be interesting for your users, you've got this PR ready to merge.

Hope it can help you.