### PR TITLE
Update lorisleiva/laravel-docker to 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lorisleiva/laravel-docker:7.4
+FROM lorisleiva/laravel-docker:8.0
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
I am getting error with:
 Root composer.json requires php ^8.0 but your php version (7.4.19) does not satisfy that requirement.
 probably because of lorisleiva/laravel-docker:7.4